### PR TITLE
Add `--staged-only` option

### DIFF
--- a/git-format-staged
+++ b/git-format-staged
@@ -36,7 +36,7 @@ def fatal(msg):
     print('{}: error: {}'.format(PROG, msg), file=sys.stderr)
     exit(1)
 
-def format_staged_files(file_patterns, formatter, git_root, update_working_tree=True, write=True):
+def format_staged_files(file_patterns, formatter, git_root, update_working_tree=True, write=True, staged_only=False):
     try:
         output = subprocess.check_output([
             'git', 'diff-index',
@@ -50,7 +50,7 @@ def format_staged_files(file_patterns, formatter, git_root, update_working_tree=
             entry_path = normalize_path(entry['src_path'], relative_to=git_root)
             if not (matches_some_path(file_patterns, entry_path)):
                 continue
-            if format_file_in_index(formatter, entry, update_working_tree=update_working_tree, write=write):
+            if format_file_in_index(formatter, entry, update_working_tree=update_working_tree, write=write, staged_only=staged_only):
                 info('Reformatted {} with {}'.format(entry['src_path'], formatter))
     except Exception as err:
         fatal(str(err))
@@ -58,7 +58,7 @@ def format_staged_files(file_patterns, formatter, git_root, update_working_tree=
 # Run formatter on file in the git index. Creates a new git object with the
 # result, and replaces the content of the file in the index with that object.
 # Returns hash of the new object if formatting produced any changes.
-def format_file_in_index(formatter, diff_entry, update_working_tree=True, write=True):
+def format_file_in_index(formatter, diff_entry, update_working_tree=True, write=True, staged_only=False):
     orig_hash = diff_entry['dst_hash']
     new_hash = format_object(formatter, orig_hash, diff_entry['src_path'])
 
@@ -66,11 +66,24 @@ def format_file_in_index(formatter, diff_entry, update_working_tree=True, write=
     if not write or new_hash == orig_hash:
         return None
 
-    replace_file_in_index(diff_entry, new_hash)
+    if not staged_only:
+        replace_file_in_index(diff_entry, new_hash)
+    else:
+        # If we want to format only the staged changes, create a formatted
+        # variant of the HEAD version. Diff that with the formatted staged
+        # version. We then replace the staged hunk by this new one via reverting
+        # the diff between working tree and staged and application of the
+        # formatted diff.
+        head_hash = diff_entry['src_hash']
+        formatted_head_hash = format_object(formatter, head_hash, diff_entry['src_path'])
+        revert_and_apply(diff_entry['src_hash'], orig_hash, formatted_head_hash, new_hash, diff_entry['src_path'], False)
 
     if update_working_tree:
         try:
-            patch_working_file(diff_entry['src_path'], orig_hash, new_hash)
+            if staged_only:
+                revert_and_apply(diff_entry['src_hash'], orig_hash, formatted_head_hash, new_hash, diff_entry['src_path'], True)
+            else:
+                patch_working_file(diff_entry['src_path'], orig_hash, new_hash)
         except Exception as err:
             # Errors patching working tree files are not fatal
             warn(str(err))
@@ -139,6 +152,44 @@ def patch_working_file(path, orig_object_hash, new_object_hash):
 
     output, err = apply_patch.communicate(input=patch_b)
 
+    if apply_patch.returncode != 0:
+        raise Exception('could not apply formatting changes to working tree file {}'.format(path))
+
+def revert_and_apply(src_rev, dst_rev, src_apply, dst_apply, path, use_cache):
+    patch_to_revert = subprocess.check_output(
+        ['git', 'diff', src_rev, dst_rev]
+    )
+    patch = subprocess.check_output(
+        ['git', 'diff', src_apply, dst_apply]
+    )
+    patch_b = patch.replace(src_apply.encode(), path).replace(dst_apply.encode(), path)
+    patch_to_revert_b = patch_to_revert.replace(src_rev.encode(), path).replace(dst_rev.encode(), path)
+
+    if use_cache:
+        cmd_revert = ['git', 'apply', '-R', '--cached', '-']
+        cmd_apply  = ['git', 'apply', '--cached', '-']
+    else:
+        cmd_revert = ['git', 'apply', '-R', '-']
+        cmd_apply  = ['git', 'apply', '-']
+
+    apply_patch_reverse = subprocess.Popen(
+        cmd_revert,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+        )
+    output, err = apply_patch_reverse.communicate(input=patch_to_revert_b)
+    if apply_patch_reverse.returncode != 0:
+        raise Exception('could not revert to original state in working tree file {}'.format(path))
+
+    # This can fail if the formatting is the reverse of the staged commit.
+    apply_patch = subprocess.Popen(
+        cmd_apply,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+        )
+    output, err = apply_patch.communicate(input=patch_b)
     if apply_patch.returncode != 0:
         raise Exception('could not apply formatting changes to working tree file {}'.format(path))
 
@@ -228,6 +279,11 @@ if __name__ == '__main__':
             help='Prevents %(prog)s from modifying staged or working tree files. You can use this option to check staged changes with a linter instead of formatting. With this option stdout from the formatter command is ignored. Example: %(prog)s --no-write -f "eslint --stdin >&2" "*.js"'
             )
     parser.add_argument(
+            '--staged-only',
+            action='store_true',
+            help='Apply formatting to the staged parts only (default is application to all but unstaged changes).'
+            )
+    parser.add_argument(
             '--version',
             action='version',
             version='%(prog)s version {}'.format(VERSION),
@@ -245,5 +301,6 @@ if __name__ == '__main__':
             formatter=vars(args)['formatter'],
             git_root=get_git_root(),
             update_working_tree=not vars(args)['no_update_working_tree'],
-            write=not vars(args)['no_write']
+            write=not vars(args)['no_write'],
+            staged_only=vars(args)['staged_only']
             )


### PR DESCRIPTION
This option allows to limit the formatting to the staged changes only. This is
done via getting the difference between the formatted cached version and the
formatted staged version. That diff represents the formatted staged changes and
can be applied after reverting the original staged change.

solves #2 