### PR TITLE
Minimize context on patch applied to working tree

### DIFF
--- a/git-format-staged
+++ b/git-format-staged
@@ -124,14 +124,14 @@ def replace_file_in_index(diff_entry, new_object_hash):
 
 def patch_working_file(path, orig_object_hash, new_object_hash):
     patch = subprocess.check_output(
-            ['git', 'diff', orig_object_hash, new_object_hash]
+            ['git', 'diff', '--unified=0', orig_object_hash, new_object_hash]
             )
 
     # Substitute object hashes in patch header with path to working tree file
     patch_b = patch.replace(orig_object_hash.encode(), path.encode()).replace(new_object_hash.encode(), path.encode())
 
     apply_patch = subprocess.Popen(
-            ['git', 'apply', '-'],
+            ['git', 'apply', '--unidiff-zero', '-'],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE

--- a/test/git-format-staged_test.js
+++ b/test/git-format-staged_test.js
@@ -134,7 +134,7 @@ test('reports descriptive error if formatter command is not found', async t => {
     '-f imaginaryformatter *.js'
   )
   t.true(exitCode > 0)
-  t.regex(stderr, /imaginaryformatter: not found/)
+  t.regex(stderr, /imaginaryformatter: (command )?not found/)
 })
 
 test('fails if no files are given', async t => {


### PR DESCRIPTION
First off, thanks for this tool! It solves exactly the problem my team is facing.

By removing context lines from the patch, we can maximize the chances that formatting changes will still apply to the working tree.

This improves the behavior when doing `git add --patch` and then using `s` to pick and choose a subset of changed lines that are close together.

I'm not entirely sure how safe this, or what the downsides are of losing the diff context. It seems to be working well in my personal testing.