### PR TITLE
Replace sys.stderr with sys.stdout

### DIFF
--- a/git-format-staged
+++ b/git-format-staged
@@ -27,7 +27,7 @@ VERSION = '$VERSION'
 PROG = sys.argv[0]
 
 def info(msg):
-    print(msg, file=sys.stderr)
+    print(msg, file=sys.stdout)
 
 def warn(msg):
     print('{}: warning: {}'.format(PROG, msg), file=sys.stderr)

--- a/test/git-format-staged_test.ts
+++ b/test/git-format-staged_test.ts
@@ -252,8 +252,8 @@ test('displays a message if a file was changed', async t => {
     `
   )
   await stage(r, 'index.js')
-  const { stderr } = await formatStaged(r, '-f prettier-standard *.js')
-  t.regex(stderr, /Reformatted index\.js with prettier-standard/)
+  const { stdout } = await formatStaged(r, '-f prettier-standard *.js')
+  t.regex(stdout, /Reformatted index\.js with prettier-standard/)
 })
 
 test('does not display a message if formatting did not produce any changes', async t => {


### PR DESCRIPTION
Replace sys.stderr with sys.stdout to output info messages to standard output instead of standard error

This will help if you want to redirect info outputs to /dev/null and just care about the errors.