### PR TITLE
Fix piping of large files

### DIFF
--- a/git-format-staged
+++ b/git-format-staged
@@ -96,30 +96,18 @@ def format_object(formatter, object_hash, file_path):
             stdout=subprocess.PIPE
             )
     format_content = subprocess.Popen(
-            re.sub(file_path_placeholder, file_path, formatter),
+            re.sub(file_path_placeholder, file_path, formatter) + ' | git hash-object -w --stdin',
             shell=True,
             stdin=get_content.stdout,
             stdout=subprocess.PIPE
             )
-    write_object = subprocess.Popen(
-            ['git', 'hash-object', '-w', '--stdin'],
-            stdin=format_content.stdout,
-            stdout=subprocess.PIPE
-            )
-
+    
     get_content.stdout.close()
-    format_content.stdout.close()
 
-    if get_content.wait() != 0:
-        raise ValueError('unable to read file content from object database: ' + object_hash)
+    new_hash, err = format_content.communicate()
 
-    if format_content.wait() != 0:
-        raise Exception('formatter exited with non-zero status') # TODO: capture stderr from format command
-
-    new_hash, err = write_object.communicate()
-
-    if write_object.returncode != 0:
-        raise Exception('unable to write formatted content to object database')
+    if format_content.returncode != 0:
+        raise Exception('unable to format and write formatted content to object database')
 
     return new_hash.decode('utf-8').rstrip()
 


### PR DESCRIPTION
Currently, when trying to format a large file (>2k lines), the `git-format-staged` tool fails with

```
/opt/homebrew/bin/git-format-staged: error: unable to read file content from object database: 6a148d0b3a9fc4f18521b0781158c6d0b152d2a8
```

I believe this happens because the buffer for pipes fills up and this fails the read process. 

The proposed fix removes this issue by using shell pipes for the second part of the pipeline (formatting + writing). Also I've removed `wait()`, because in the python docs wait isn't used: https://docs.python.org/3/library/subprocess.html#replacing-shell-pipeline

Tested the same formatter on the same large file and it now works properly. If more tests are needed, I would be glad to help
