### PR TITLE
feat: switch executable command to python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: python
 python:
   - 3.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - 3.8
-  - 3.6
+  - 3.10
+  - 3.9
   - 2.7
 
 cache:

--- a/git-format-staged
+++ b/git-format-staged
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Git command to transform staged files according to a command that accepts file
 # content on stdin and produces output on stdout. This command is useful in
@@ -9,7 +9,7 @@
 # Usage: git-format-staged [OPTION]... [FILE]...
 # Example: git-format-staged --formatter 'prettier --stdin-filepath "{}"' '*.js'
 #
-# Tested with Python 3.6 and Python 2.7.
+# Tested with Python 3.10 and Python 2.7.
 #
 # Original author: Jesse Hallett <jesse@sitr.us>
 


### PR DESCRIPTION
I'm told that the correct thing to do is to run Python scripts with `python3` since `python` continues to reference v2. Fixes #67.

This change also updates the CI testing matrix to test against Python versions 3.10, 3.9, and 2.7.

BREAKING CHANGE: git-format-staged now runs with `python3` instead of `python`. You will need to have `python3` in your executable path.