### PR TITLE
fix: disable external diff tools when generating diffs

### DIFF
--- a/git-format-staged
+++ b/git-format-staged
@@ -145,7 +145,7 @@ def replace_file_in_index(diff_entry, new_object_hash):
 
 def patch_working_file(path, orig_object_hash, new_object_hash):
     patch = subprocess.check_output(
-            ['git', 'diff', '--color=never', orig_object_hash, new_object_hash]
+            ['git', 'diff', '--no-ext-diff', '--color=never', orig_object_hash, new_object_hash]
             )
 
     # Substitute object hashes in patch header with path to working tree file


### PR DESCRIPTION
I was wondering why git-format-staged would fail to apply trivial reformatting patches on my machine... The reason is that I use [difftastic](https://github.com/Wilfred/difftastic) as a diff tool, and that does not generate output that `git apply` can understand... Adding `--no-ext-diff` to the `git diff` command line fixes the issue.