### PR TITLE
feat: add --verbose option to git-format-staged

### DIFF
--- a/git-format-staged
+++ b/git-format-staged
@@ -97,7 +97,7 @@ def format_object(formatter, object_hash, file_path, verbose=False):
             )
     command = re.sub(file_path_placeholder, file_path, formatter)
     if verbose:
-        print(command)
+        info(command)
     format_content = subprocess.Popen(
             command,
             shell=True,

--- a/git-format-staged
+++ b/git-format-staged
@@ -36,7 +36,7 @@ def fatal(msg):
     print('{}: error: {}'.format(PROG, msg), file=sys.stderr)
     exit(1)
 
-def format_staged_files(file_patterns, formatter, git_root, update_working_tree=True, write=True):
+def format_staged_files(file_patterns, formatter, git_root, update_working_tree=True, write=True, verbose=False):
     try:
         output = subprocess.check_output([
             'git', 'diff-index',
@@ -53,7 +53,7 @@ def format_staged_files(file_patterns, formatter, git_root, update_working_tree=
                 continue
             if not (matches_some_path(file_patterns, entry_path)):
                 continue
-            if format_file_in_index(formatter, entry, update_working_tree=update_working_tree, write=write):
+            if format_file_in_index(formatter, entry, update_working_tree=update_working_tree, write=write, verbose=verbose):
                 info('Reformatted {} with {}'.format(entry['src_path'], formatter))
     except Exception as err:
         fatal(str(err))
@@ -61,9 +61,9 @@ def format_staged_files(file_patterns, formatter, git_root, update_working_tree=
 # Run formatter on file in the git index. Creates a new git object with the
 # result, and replaces the content of the file in the index with that object.
 # Returns hash of the new object if formatting produced any changes.
-def format_file_in_index(formatter, diff_entry, update_working_tree=True, write=True):
+def format_file_in_index(formatter, diff_entry, update_working_tree=True, write=True, verbose=False):
     orig_hash = diff_entry['dst_hash']
-    new_hash = format_object(formatter, orig_hash, diff_entry['src_path'])
+    new_hash = format_object(formatter, orig_hash, diff_entry['src_path'], verbose=verbose)
 
     # If the new hash is the same then the formatter did not make any changes.
     if not write or new_hash == orig_hash:
@@ -90,13 +90,16 @@ file_path_placeholder = re.compile('\{\}')
 
 # Run formatter on a git blob identified by its hash. Writes output to a new git
 # blob, and returns the hash of the new blob.
-def format_object(formatter, object_hash, file_path):
+def format_object(formatter, object_hash, file_path, verbose=False):
     get_content = subprocess.Popen(
             ['git', 'cat-file', '-p', object_hash],
             stdout=subprocess.PIPE
             )
+    command = re.sub(file_path_placeholder, file_path, formatter)
+    if verbose:
+        print(command)
     format_content = subprocess.Popen(
-            re.sub(file_path_placeholder, file_path, formatter),
+            command,
             shell=True,
             stdin=get_content.stdout,
             stdout=subprocess.PIPE
@@ -255,6 +258,11 @@ if __name__ == '__main__':
             help='Display version of %(prog)s'
             )
     parser.add_argument(
+            '--verbose',
+            help='Show the formatting commands that are running',
+            action='store_true'
+            )
+    parser.add_argument(
             'files',
             nargs='+',
             help='Patterns that specify files to format. The formatter will only transform staged files that are given here. Patterns may be literal file paths, or globs which will be tested against staged file paths using Python\'s fnmatch function. For example "src/*.js" will match all files with a .js extension in src/ and its subdirectories. Patterns may be negated to exclude files using a "!" character. Patterns are evaluated left-to-right. (Example: "main.js" "src/*.js" "test/*.js" "!test/todo/*")'
@@ -266,5 +274,6 @@ if __name__ == '__main__':
             formatter=vars(args)['formatter'],
             git_root=get_git_root(),
             update_working_tree=not vars(args)['no_update_working_tree'],
-            write=not vars(args)['no_write']
+            write=not vars(args)['no_write'],
+            verbose=vars(args)['verbose']
             )


### PR DESCRIPTION
Add a --verbose option to the script that prints out the format commands as they are executed.

Fixes #58 