### PR TITLE
fix: avoid deadlock when accessing git object for large file

### DIFF
--- a/git-format-staged
+++ b/git-format-staged
@@ -110,15 +110,9 @@ def format_object(formatter, object_hash, file_path, verbose=False):
             stdout=subprocess.PIPE
             )
 
-    get_content.stdout.close()
-    format_content.stdout.close()
-
-    if get_content.wait() != 0:
-        raise ValueError('unable to read file content from object database: ' + object_hash)
-
-    if format_content.wait() != 0:
-        raise Exception('formatter exited with non-zero status') # TODO: capture stderr from format command
-
+    get_content.communicate()
+    format_content.communicate()
+    
     new_hash, err = write_object.communicate()
 
     if write_object.returncode != 0:


### PR DESCRIPTION
Thanks to @scamille for this fix!

Fixes #88 