### PR TITLE
fix: use raw strings for regex

### DIFF
--- a/git-format-staged
+++ b/git-format-staged
@@ -86,7 +86,7 @@ def format_file_in_index(formatter, diff_entry, update_working_tree=True, write=
 
     return new_hash
 
-file_path_placeholder = re.compile('\{\}')
+file_path_placeholder = re.compile(r'\{\}')
 
 # Run formatter on a git blob identified by its hash. Writes output to a new git
 # blob, and returns the hash of the new blob.
@@ -167,7 +167,7 @@ def patch_working_file(path, orig_object_hash, new_object_hash):
         raise Exception('could not apply formatting changes to working tree file {}'.format(path))
 
 # Format: src_mode dst_mode src_hash dst_hash status/score? src_path dst_path?
-diff_pat = re.compile('^:(\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([A-Z])(\d+)?\t([^\t]+)(?:\t([^\t]+))?$')
+diff_pat = re.compile(r'^:(\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([A-Z])(\d+)?\t([^\t]+)(?:\t([^\t]+))?$')
 
 # Parse output from `git diff-index`
 def parse_diff(diff):
@@ -185,7 +185,7 @@ def parse_diff(diff):
             'dst_path': m.group(8)
             }
 
-zeroed_pat = re.compile('^0+$')
+zeroed_pat = re.compile(r'^0+$')
 
 # Returns the argument unless the argument is a string of zeroes, in which case
 # returns `None`


### PR DESCRIPTION
As of https://github.com/python/cpython/issues/98401 (released in Python 3.12.0), invalid escape sequences emit louder warnings, as described in #89 and #33. This patch uses raw strings for compiled regexes to suppress the warnings.

I'm definitely not a Python expert, so I'm very open to input about other ways to solve the problem!