### PR TITLE
ci: automatically update npm dependencies hash in dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-post.yml
+++ b/.github/workflows/dependabot-post.yml
@@ -1,0 +1,44 @@
+# Due to the Nix configuration we need to update a hash in test/test.nix when
+# npm dependencies change. This workflow runs on dependabot branches, and runs
+# a script that makes the necessary update after each dependabot push.
+name: Dependabot-post
+on:
+  push:
+    branches:
+      - "dependabot/npm_and_yarn/*"
+
+jobs:
+  update_npm_deps_hash:
+    name: Update NPM dependencies hash
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Configure Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Update Hash
+        run: nix run .#update-npm-deps-hash
+
+      - name: Set up Git Config
+        run: |
+          git config user.name 'GitHub Actions Bot'
+          git config user.email '<>'
+
+      # NOTE: Prefixing/appending commit messages with `[dependabot skip]`
+      # allows dependabot to rebase/update the pull request, force-pushing
+      # over any changes
+      - name: Commit changes
+        run: |
+          git add .
+          if [[ $(git status -s) ]]; then
+            git commit -m "build(deps): update npm dependencies hash [dependabot skip]" --no-verify
+            git push
+            echo "Pushed an update to npm dependencies hash"
+          else
+            echo "Npm dependencies hash was not changed"
+          fi

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,18 @@
     {
       packages = eachSystem (pkgs: {
         default = pkgs.callPackage ./packages/git-format-staged.nix { };
+
+        # When npm dependencies change we need to update the dependencies hash
+        # in test/test.nix
+        update-npm-deps-hash = pkgs.writeShellApplication {
+          name = "update-npm-deps-hash";
+          runtimeInputs = with pkgs; [ prefetch-npm-deps nix gnused ];
+          text = ''
+            hash=$(prefetch-npm-deps package-lock.json 2>/dev/null)
+            echo "updated npm dependency hash: $hash" >&2
+            sed -i "s|sha256-[A-Za-z0-9+/=]\+|$hash|" test/test.nix
+          '';
+        };
       });
 
       devShells = eachSystem (pkgs: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11085,9 +11085,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -20120,9 +20120,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11085,9 +11085,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -20120,9 +20120,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true
     },
     "uglify-js": {


### PR DESCRIPTION
Due to the Nix configuration we need to update a hash in `test/test.nix` when npm dependencies change. This workflow runs on dependabot branches, and runs a script that makes the necessary update after each dependabot push.
