### PR TITLE
Upgrade.to actions/checkout@v4

### DIFF
--- a/.github/workflows/dependabot-post.yml
+++ b/.github/workflows/dependabot-post.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main


### PR DESCRIPTION
https://github.com/actions/checkout/releases

Fixes the software supply chain safety warning at the bottom right of
https://github.com/hallettj/git-format-staged/actions/runs/8211643604