### PR TITLE
Fix installation via nix profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ patch step can be disabled with the `--no-update-working-tree` option.
 
 Install via the CLI:
 
-    $ nix profile add github:hallettj/git-format-staged
+    $ nix profile install github:hallettj/git-format-staged
 
 Or add to your flake imports, and use the `default` package output.
 


### PR DESCRIPTION
With Nix `2.18.8`, `nix profile add`  gave me

```
error: 'add' is not a recognised command
```

`nix profile install github:hallettj/git-format-staged` works for me.