### PR TITLE
Add placeholder for absolute path

### DIFF
--- a/git-format-staged
+++ b/git-format-staged
@@ -47,11 +47,11 @@ def format_staged_files(file_patterns, formatter, git_root, update_working_tree=
             ])
         for line in output.splitlines():
             entry = parse_diff(line.decode('utf-8'))
-            entry_path = normalize_path(entry['src_path'], relative_to=git_root)
+            entry['src_path_absolute'] = normalize_path(entry['src_path'], relative_to=git_root)
             if entry['dst_mode'] == '120000':
                 # Do not process symlinks
                 continue
-            if not (matches_some_path(file_patterns, entry_path)):
+            if not (matches_some_path(file_patterns, entry['src_path_absolute'])):
                 continue
             if format_file_in_index(formatter, entry, update_working_tree=update_working_tree, write=write, verbose=verbose):
                 info('Reformatted {} with {}'.format(entry['src_path'], formatter))
@@ -63,7 +63,7 @@ def format_staged_files(file_patterns, formatter, git_root, update_working_tree=
 # Returns hash of the new object if formatting produced any changes.
 def format_file_in_index(formatter, diff_entry, update_working_tree=True, write=True, verbose=False):
     orig_hash = diff_entry['dst_hash']
-    new_hash = format_object(formatter, orig_hash, diff_entry['src_path'], verbose=verbose)
+    new_hash = format_object(formatter, orig_hash, diff_entry['src_path'], diff_entry['src_path_absolute'], verbose=verbose)
 
     # If the new hash is the same then the formatter did not make any changes.
     if not write or new_hash == orig_hash:
@@ -90,12 +90,13 @@ file_path_placeholder = re.compile(r'\{\}')
 
 # Run formatter on a git blob identified by its hash. Writes output to a new git
 # blob, and returns the hash of the new blob.
-def format_object(formatter, object_hash, file_path, verbose=False):
+def format_object(formatter, object_hash, file_path, file_path_absolute, verbose=False):
     get_content = subprocess.Popen(
             ['git', 'cat-file', '-p', object_hash],
             stdout=subprocess.PIPE
             )
     command = re.sub(file_path_placeholder, file_path, formatter)
+    command = command.replace('{abs}', file_path_absolute)
     if verbose:
         info(command)
     format_content = subprocess.Popen(
@@ -239,7 +240,7 @@ if __name__ == '__main__':
     parser.add_argument(
             '--formatter', '-f',
             required=True,
-            help='Shell command to format files, will run once per file. Occurrences of the placeholder `{}` will be replaced with a path to the file being formatted. (Example: "prettier --stdin-filepath \'{}\'")'
+            help='Shell command to format files, will run once per file. Occurrences of the placeholder `{}` will be replaced with a relative path to the file being formatted. (Example: "prettier --stdin-filepath \'{}\'"). Use `{abs}` for an absolute path.'
             )
     parser.add_argument(
             '--no-update-working-tree',


### PR DESCRIPTION
Added a new placeholder "{abs}" which will be replaced with the absolute file path.

I wanted to use the script with ktlint, but ktlint obviously only works with absolute path names.