### PR TITLE
Add homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Or install globally:
 
     $ npm install --global git-format-staged
 
+### Install with Homebrew
+
+Install globally using [homebrew]:
+
+    $ brew install git-format-staged
+
+[homebrew]: https://brew.sh/
+
 ### Or just copy the script
 
 Requires Python 3.8 or later.


### PR DESCRIPTION
I've added a formula for it in https://github.com/Homebrew/homebrew-core/pull/275581 -- it should [automatically follow future versions](https://docs.brew.sh/Autobump) so this shouldn't add any maintenance burden.