### PR TITLE
Ignore submodules

### DIFF
--- a/git-format-staged
+++ b/git-format-staged
@@ -76,8 +76,8 @@ def format_staged_files(
         output = subprocess.check_output(["git", "diff-index"] + common_opts)
         for line in output.splitlines():
             entry = DiffIndexEntry(line.decode("utf-8"))
-            if entry.dst_mode == "120000":
-                # Do not process symlinks
+            if entry.dst_mode in ("120000", "160000"):
+                # Do not process symlinks or submodules
                 continue
             if not (matches_some_path(file_patterns, entry.src_path)):
                 continue


### PR DESCRIPTION
Currently, the tool fails attempting to read submodule object names, for example:

```shell
$ git init .
$ git commit --allow-empty -m 'root'
$ git submodule add https://github.com/hallettj/git-format-staged.git my-submodule
$ git diff-index --cached --diff-filter=AM --no-renames HEAD
:100644 100644 e15b682c9ae653ef7543156ee67e33f945f88186 bdb710922480133c476453e020c35f62e10673e3 M	.gitmodules
:000000 160000 0000000000000000000000000000000000000000 1aaddc4fc1c2a27138241bc84c7b3934a4766459 A	my-submodule
$ git-format-staged --no-write --verbose -f cat '*'
cat
fatal: Not a valid object name 1aaddc4fc1c2a27138241bc84c7b3934a4766459
git-format-staged: error: unable to verify content of formatted object
```

160000 is the [special mode](https://git-scm.com/docs/gitdatamodel) for gitlinks, we can just ignore this as we do symlinks and things work as expected